### PR TITLE
Hashicorp Vault setup

### DIFF
--- a/infrastructure/records.yml
+++ b/infrastructure/records.yml
@@ -6,4 +6,8 @@
 #
 
 waffle-primary:
+  # Infrastructure services
+  - vault.wafflehacks.tech
+
+  # Deployed services
   - cms.wafflehacks.tech


### PR DESCRIPTION
Adds a DNS record for [Vault](https://vaultproject.io).