### PR TITLE
Complete domain migration

### DIFF
--- a/apply-mailer.toml
+++ b/apply-mailer.toml
@@ -10,7 +10,7 @@
   postgres = { name = "DATABASE_URL", role = "apply" }
 
 [environment]
-  hm_domain_name = "apply.wafflehacks.tech"
+  hm_domain_name = "apply.wafflehacks.org"
   hm_protocol = "https"
 
   lang = "en_US.UTF-8"

--- a/apply.toml
+++ b/apply.toml
@@ -7,7 +7,7 @@
   postgres = "DATABASE_URL"
 
 [environment]
-  hm_domain_name = "apply.wafflehacks.tech"
+  hm_domain_name = "apply.wafflehacks.org"
   hm_protocol = "https"
 
   lang = "en_US.UTF-8"

--- a/cms.toml
+++ b/cms.toml
@@ -7,7 +7,7 @@
   postgres = "DB_CONNECTION_STRING"
 
 [environment]
-  public_url = "https://cms.wafflehacks.tech"
+  public_url = "https://cms.wafflehacks.org"
 
   db_client = "pg"
 
@@ -15,8 +15,8 @@
   cache_store = "redis"
   cache_auto_purge = "true"
 
-  admin_email = "admin@wafflehacks.tech"
-  email_from = "cms@wafflehacks.tech"
+  admin_email = "admin@wafflehacks.org"
+  email_from = "cms@wafflehacks.org"
   email_transport = "mailgun"
 
   storage_locations = "s3"

--- a/infrastructure/records.yml
+++ b/infrastructure/records.yml
@@ -7,11 +7,11 @@
 
 waffle-primary:
   # Infrastructure services
-  - deploy.wafflehacks.tech
-  - traefik.wafflehacks.tech
-  - vault.wafflehacks.tech
+  - deploy.wafflehacks.org
+  - traefik.wafflehacks.org
+  - vault.wafflehacks.org
 
   # Deployed services
-  - apply.wafflehacks.tech
-  - bot.wafflehacks.tech
-  - cms.wafflehacks.tech
+  - apply.wafflehacks.org
+  - bot.wafflehacks.org
+  - cms.wafflehacks.org

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -31,7 +31,7 @@ variable "cloudflare_token" {
 variable "domain" {
   type        = string
   description = "The domain to modify DNS records on, must be active on Cloudflare"
-  default     = "wafflehacks.tech"
+  default     = "wafflehacks.org"
 }
 
 variable "project" {

--- a/wafflebot-discord.toml
+++ b/wafflebot-discord.toml
@@ -18,7 +18,7 @@
 
   bot_disabled_extensions = ""
 
-  bot_hm_url = "https://apply.wafflehacks.tech"
+  bot_hm_url = "https://apply.wafflehacks.org"
 
 [secrets]
   discord_token = "load"


### PR DESCRIPTION
This finishes the migration from wafflehacks.tech to wafflehacks.org. Once merged, a page rule should be manually configured to redirect all traffic to wafflehacks.org.